### PR TITLE
Fix the filterComputes check

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -190,10 +190,13 @@ const getComputeById = async () => {
 const filterComputes = async () => {
     process.stdout.write(chalk.blue('filtering Computes by labels'));
     const randomCompute = getRandomMathResponse()
-    const label = getRandomMathResponse().metadata.labels[Math.floor(Math.random()*randomCompute.metadata.labels.length)]
+    const label = randomCompute.metadata.labels[Math.floor(Math.random()*randomCompute.metadata.labels.length)]
     const searchResults = await api.computeGet(label.key, 'equals', label.value);
     if (searchResults.response.statusCode == 200) {
         const mathResponses:MathResponse[] = searchResults.body;
+        if (mathResponses.length > 1) {
+            testFailed('GET request filtered by label returned too many responses: ' + mathResponses.length)
+        }
         let matched:Boolean = false;
         mathResponses.map( (mathResponse) => {
             if (mathResponse.id == randomCompute.id) {


### PR DESCRIPTION
Fixing a pair of bugs in the filterComputes function:

1. The client requests a random compute to check the id of and then requests a second random compute to get the labels from, so most of the time the id it's checking doesn't actually correspond to the label it requested be filtered to.
2. The client then maps across the whole response looking for the first random id selected instead of either only checking the first response or checking the response size - amusingly, this means if your filter doesn't actually do anything this test passes as the random id is present.

Given the structure of the tests, I'm presuming you will only have one filtered response if your filter is functioning correctly.